### PR TITLE
Fix octal numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: 'Install covimerage and coveralls'
         if: matrix.coverage_cmd != ''
         run: |
+          pip install 'click<8.0.0'
           pip install --upgrade pip
           pip install covimerage coveralls
           covimerage --version

--- a/tests/oct.vader
+++ b/tests/oct.vader
@@ -7,6 +7,7 @@ After:
   unlet g:numbers_test_textobj
 
 Given (valid octal numbers):
+  0o2322
      02322
     0o2322   
     0O2322   
@@ -14,6 +15,7 @@ Given (valid octal numbers):
 
 Execute (only the octal numbers were selected):
   let expected = [
+    \[1, 6],
     \[4, 8],
     \[3, 8],
     \[3, 8],


### PR DESCRIPTION
Fixes a bug selecting octal numbers at start of lines and also makes selecting octal numbers with multiple valid prefixes, e.g. `041407357` more robust.
